### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # check for updates daily
+      interval: "daily"
+    # target latest development branch
+    target-branch: "1.2.x"
+    # add reviewers to pull requests
+    reviewers:
+      - "Plastikmensch"
+    # Labels on pull requests for security and version updates
+    labels:
+      - "dependencies"


### PR DESCRIPTION
To avoid conflicts between master and development branches, dependabot should only check the latest development branch
Also master branch should reflect the latest release.